### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ if (!isset($_GET['code'])) {
     ];
 
     // If we don't have an authorization code then get one
-    $authUrl = $provider->getAuthorizationUrl();
+    $authUrl = $provider->getAuthorizationUrl($options);
     $_SESSION['oauth2state'] = $provider->getState();
     header('Location: '.$authUrl);
     exit;


### PR DESCRIPTION
Added an argument `$options` to `$provider->getAuthorizationUrl()`.

```php
$options = [
    'scope' => ['read_orders','write_orders'] // array or string
];
$authUrl = $provider->getAuthorizationUrl($options); // $options was missing here
```